### PR TITLE
feat: Add custom dice roll functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,6 +346,17 @@
             <span>Total: <span id="useMagicDeviceTotal">0</span></span>
           </div>
         </div> <!-- End skills -->
+
+        <div id="customRollsSection">
+          <h2>Custom Dice Rolls</h2>
+          <button id="addCustomRollBtn" aria-label="Add new custom roll" style="font-size: 1.5em; padding: 5px 10px;">+</button>
+          <div id="customRollFormContainer">
+            <!-- New custom roll forms will be injected here by JavaScript -->
+          </div>
+          <div id="customRollsDisplayContainer">
+            <!-- Saved custom rolls will be displayed here -->
+          </div>
+        </div>
       </div> <!-- End main-right-column -->
     </div> <!-- End main-content -->
   </div> <!-- End sheet-container -->

--- a/script.js
+++ b/script.js
@@ -231,4 +231,144 @@ document.addEventListener('DOMContentLoaded', () => {
   console.log("AC Total (acTotal): " + getIntValue('acTotal'));
   console.log("Fortitude Total (fortTotal): " + getIntValue('fortTotal'));
   console.log("---------------------------------");
+
+  // --- Custom Dice Rolls --- //
+  const addCustomRollBtn = document.getElementById('addCustomRollBtn');
+  const customRollFormContainer = document.getElementById('customRollFormContainer');
+  const customRollsDisplayContainer = document.getElementById('customRollsDisplayContainer');
+  let customRolls = []; // To store custom roll objects
+
+  function createNewRollForm() {
+    if (!customRollFormContainer) {
+        console.error('customRollFormContainer not found');
+        return;
+    }
+
+    const formDiv = document.createElement('div');
+    formDiv.classList.add('custom-roll-form');
+
+    let formHTML = `
+        <div>
+            <label for="rollDescription_temp">Description:</label>
+            <input type="text" class="roll-description-input" name="rollDescription_temp" placeholder="e.g., Longsword Damage">
+        </div>
+        <div><label>Dice (enter quantity):</label></div>
+        <div style="display: flex; flex-wrap: wrap;">`; // Wrapper for dice inputs
+
+    const diceTypes = ['d4', 'd6', 'd8', 'd10', 'd12', 'd20', 'd100'];
+    diceTypes.forEach(die => {
+        formHTML += `
+            <div style="margin-right: 10px; margin-bottom: 5px; display: flex; align-items: center;">
+                <label class="dice-label" for="${die}_count_temp" style="min-width: auto; margin-right: 3px;">${die}:</label>
+                <input type="number" class="dice-input" data-die="${die}" name="${die}_count_temp" value="0" min="0" style="width: 45px;">
+            </div>`;
+    });
+    formHTML += `</div>`; // End dice wrapper
+    formHTML += `<div style="margin-top: 10px;">`;
+    formHTML += `<button class="save-roll-btn">Save Roll</button>`;
+    formHTML += `<button class="cancel-roll-btn" type="button" style="margin-left: 10px; background-color: #f44336; color:white; border:none; padding: 6px 12px; border-radius:3px; cursor:pointer;">Cancel</button>`;
+    formHTML += `</div>`;
+
+    formDiv.innerHTML = formHTML;
+    customRollFormContainer.appendChild(formDiv);
+
+    const saveBtn = formDiv.querySelector('.save-roll-btn');
+    if (saveBtn) {
+        saveBtn.addEventListener('click', function(event) {
+            event.preventDefault(); 
+            const descriptionInput = formDiv.querySelector('.roll-description-input');
+            const description = descriptionInput ? descriptionInput.value.trim() : '';
+            
+            const diceCounts = [];
+            formDiv.querySelectorAll('.dice-input').forEach(input => {
+                const count = parseInt(input.value, 10);
+                if (count > 0) {
+                    diceCounts.push({ die: input.dataset.die, count: count });
+                }
+            });
+
+            if (description === '' && diceCounts.length === 0) {
+                alert("Please enter a description or at least one die for the roll.");
+                return;
+            }
+            if (diceCounts.length === 0) {
+                 alert("Please specify at least one die to roll.");
+                 return;
+             }
+
+            const newRoll = {
+                id: Date.now().toString(), // Simple unique ID
+                description: description || "Custom Roll", // Default description if empty
+                dice: diceCounts
+            };
+
+            customRolls.push(newRoll);
+            renderCustomRolls(); // New function to re-render all displayed rolls
+            formDiv.remove(); 
+        });
+    } else {
+        console.error('Save button not found in new roll form.');
+    }
+
+    const cancelBtn = formDiv.querySelector('.cancel-roll-btn');
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', function() {
+            formDiv.remove(); 
+        });
+    } else {
+        console.error('Cancel button not found in new roll form.');
+    }
+  }
+
+  function renderCustomRolls() {
+      if (!customRollsDisplayContainer) {
+          console.error('customRollsDisplayContainer not found');
+          return;
+      }
+      customRollsDisplayContainer.innerHTML = ''; // Clear existing displayed rolls
+
+      customRolls.forEach(roll => {
+          const rollDiv = document.createElement('div');
+          rollDiv.classList.add('displayed-roll');
+          rollDiv.dataset.rollId = roll.id;
+
+          const descriptionSpan = document.createElement('span');
+          descriptionSpan.classList.add('roll-description');
+          descriptionSpan.textContent = roll.description;
+
+          const diceSummarySpan = document.createElement('span');
+          diceSummarySpan.classList.add('roll-dice-summary');
+          diceSummarySpan.textContent = roll.dice.map(d => `${d.count}${d.die}`).join(' + ');
+
+          // Future: Add edit/delete buttons here if needed
+          // For now, just display. A delete button is a good next step.
+          const deleteBtn = document.createElement('button');
+          deleteBtn.textContent = 'Delete';
+          deleteBtn.style.marginLeft = '10px';
+          deleteBtn.style.padding = '3px 8px';
+          deleteBtn.style.backgroundColor = '#dc3545'; // Red color for delete
+          deleteBtn.style.color = 'white';
+          deleteBtn.style.border = 'none';
+          deleteBtn.style.borderRadius = '3px';
+          deleteBtn.style.cursor = 'pointer';
+          deleteBtn.addEventListener('click', function() {
+              customRolls = customRolls.filter(r => r.id !== roll.id);
+              renderCustomRolls(); // Re-render after deletion
+          });
+
+
+          rollDiv.appendChild(descriptionSpan);
+          rollDiv.appendChild(diceSummarySpan);
+          rollDiv.appendChild(deleteBtn); // Add delete button
+          customRollsDisplayContainer.appendChild(rollDiv);
+      });
+  }
+
+  if (addCustomRollBtn) {
+    addCustomRollBtn.addEventListener('click', createNewRollForm);
+  } else {
+    console.error('Main "Add Custom Roll" button (addCustomRollBtn) not found.');
+  }
+  renderCustomRolls(); // Initial render (will be empty at first)
+  // --- End Custom Dice Rolls --- //
 });

--- a/style.css
+++ b/style.css
@@ -198,3 +198,89 @@ span { /* General spans, often used for "Modifier:" or "Total:" text */
 #hpTotal, #acTotal {
     min-width: 30px; /* Slightly wider for potentially larger numbers */
 }
+
+/* Custom Dice Rolls Section */
+#customRollsSection {
+  border: 1px solid #aaa;
+  padding: 10px;
+  border-radius: 3px; /* Subtle rounding */
+  margin-top: 15px; /* Space from the skills section */
+}
+
+#addCustomRollBtn {
+  font-size: 1.2em; /* Make '+' clearly visible */
+  padding: 5px 10px;
+  margin-bottom: 10px; /* Space before the form container */
+  cursor: pointer;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+
+#addCustomRollBtn:hover {
+  background-color: #e0e0e0;
+}
+
+#customRollFormContainer .custom-roll-form { /* Class for individual forms */
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 10px;
+  background-color: #f9f9f9;
+  border-radius: 3px;
+}
+
+.custom-roll-form div { /* For layout of label/input pairs */
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+}
+
+.custom-roll-form label {
+  min-width: 100px; /* Adjust as needed */
+  margin-right: 5px;
+}
+
+.custom-roll-form input[type="number"] {
+  width: 50px; /* Compact size for dice counts */
+  margin-right: 10px; /* Space between dice inputs */
+}
+
+.custom-roll-form input[type="text"] { /* For description */
+  flex-grow: 1; /* Allow description to take available space */
+  padding: 5px;
+}
+
+.custom-roll-form button { /* Save button for the form */
+  padding: 6px 12px;
+  background-color: #4CAF50; /* Green for save */
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  margin-top: 5px;
+}
+
+.custom-roll-form button:hover {
+  background-color: #45a049;
+}
+
+#customRollsDisplayContainer .displayed-roll { /* Class for individual displayed rolls */
+  border: 1px solid #ddd;
+  padding: 8px;
+  margin-bottom: 8px;
+  background-color: #fff;
+  border-radius: 3px;
+  display: flex;
+  justify-content: space-between; /* For description and dice string */
+  align-items: center;
+}
+
+.displayed-roll .roll-description {
+  font-weight: bold;
+  margin-right: 10px;
+}
+
+.displayed-roll .roll-dice-summary {
+  font-family: monospace; /* Good for dice strings like 2d6+1d4 */
+  font-size: 0.95em;
+}

--- a/test_custom_rolls.py
+++ b/test_custom_rolls.py
@@ -1,0 +1,115 @@
+import asyncio
+from playwright.async_api import async_playwright, expect
+
+async def main():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        page = await browser.new_page()
+        
+        # Get the absolute path to index.html
+        # Assuming script is run from the root of the repo
+        import os
+        html_file_path = "file://" + os.path.abspath("index.html")
+
+        print(f"Loading page: {html_file_path}")
+        await page.goto(html_file_path)
+
+        # --- Test Plan ---
+
+        # 1. Load `index.html` (done by page.goto)
+
+        # 2. Initial State Check
+        print("Checking initial state...")
+        await expect(page.locator("#addCustomRollBtn")).to_be_visible()
+        await expect(page.locator("#customRollFormContainer")).to_be_empty()
+        await expect(page.locator("#customRollsDisplayContainer")).to_be_empty()
+        print("Initial state OK.")
+
+        # 3. Add Form and Cancel
+        print("Testing Add Form and Cancel...")
+        await page.locator("#addCustomRollBtn").click()
+        await expect(page.locator("#customRollFormContainer")).to_have_count(1) # Should have one child (the form)
+        await expect(page.locator("#customRollFormContainer > .custom-roll-form")).to_be_visible()
+        await page.locator("#customRollFormContainer .cancel-roll-btn").click()
+        await expect(page.locator("#customRollFormContainer")).to_be_empty()
+        print("Add Form and Cancel OK.")
+
+        # 4. Add Form, Input Data, and Save Valid Roll
+        print("Testing Add Form, Input Data, and Save Valid Roll...")
+        await page.locator("#addCustomRollBtn").click()
+        await page.locator("#customRollFormContainer .roll-description-input").fill("Test Dragon Breath")
+        await page.locator("#customRollFormContainer input[data-die='d6']").fill("3")
+        await page.locator("#customRollFormContainer input[data-die='d10']").fill("1")
+        await page.locator("#customRollFormContainer .save-roll-btn").click()
+        
+        await expect(page.locator("#customRollFormContainer")).to_be_empty()
+        await expect(page.locator("#customRollsDisplayContainer > .displayed-roll")).to_have_count(1)
+        
+        first_roll = page.locator("#customRollsDisplayContainer > .displayed-roll").first
+        await expect(first_roll.locator(".roll-description")).to_have_text("Test Dragon Breath")
+        await expect(first_roll.locator(".roll-dice-summary")).to_have_text("3d6 + 1d10")
+        await expect(first_roll.locator("button:has-text('Delete')")).to_be_visible()
+        print("Add Form, Input Data, and Save Valid Roll OK.")
+
+        # 5. Save Roll with No Description (Uses Default)
+        print("Testing Save Roll with No Description...")
+        await page.locator("#addCustomRollBtn").click()
+        await page.locator("#customRollFormContainer input[data-die='d20']").fill("1")
+        await page.locator("#customRollFormContainer .save-roll-btn").click()
+
+        await expect(page.locator("#customRollsDisplayContainer > .displayed-roll")).to_have_count(2)
+        second_roll = page.locator("#customRollsDisplayContainer > .displayed-roll").nth(1)
+        await expect(second_roll.locator(".roll-description")).to_have_text("Custom Roll")
+        await expect(second_roll.locator(".roll-dice-summary")).to_have_text("1d20")
+        print("Save Roll with No Description OK.")
+
+        # 6. Attempt to Save Roll with No Dice (Should Fail)
+        print("Testing Attempt to Save Roll with No Dice...")
+        # Setup to catch alerts
+        alert_messages = []
+        dialog_handler = lambda dialog: (alert_messages.append(dialog.message), asyncio.create_task(dialog.dismiss()))
+        page.on("dialog", dialog_handler)
+
+        await page.locator("#addCustomRollBtn").click()
+        await page.locator("#customRollFormContainer .roll-description-input").fill("Invalid Test")
+        # Ensure dice inputs are 0 (default)
+        await page.locator("#customRollFormContainer .save-roll-btn").click()
+
+        await expect(page.locator("#customRollFormContainer > .custom-roll-form")).to_be_visible() # Form should still be there
+        await expect(page.locator("#customRollsDisplayContainer > .displayed-roll")).to_have_count(2) # No new roll added
+        
+        # Check for alert message (optional, but good to verify)
+        # This is a bit tricky with async, ensure the event has time to fire
+        await page.wait_for_timeout(100) # give a bit of time for dialog event
+        if "Please specify at least one die to roll." not in alert_messages:
+             print(f"Warning: Expected alert 'Please specify at least one die to roll.' not found. Alerts received: {alert_messages}")
+
+
+        # Clean up
+        await page.locator("#customRollFormContainer .cancel-roll-btn").click()
+        await expect(page.locator("#customRollFormContainer")).to_be_empty()
+        print("Attempt to Save Roll with No Dice OK (form remained, no new roll).")
+        page.remove_listener("dialog", dialog_handler) # remove listener
+
+        # 7. Delete a Roll
+        print("Testing Delete a Roll...")
+        await expect(page.locator("#customRollsDisplayContainer > .displayed-roll")).to_have_count(2)
+        # Click delete on the first roll ("Test Dragon Breath")
+        await page.locator("#customRollsDisplayContainer > .displayed-roll").first.locator("button:has-text('Delete')").click()
+        
+        await expect(page.locator("#customRollsDisplayContainer > .displayed-roll")).to_have_count(1)
+        remaining_roll = page.locator("#customRollsDisplayContainer > .displayed-roll").first
+        await expect(remaining_roll.locator(".roll-description")).to_have_text("Custom Roll") # The d20 roll
+        print("Delete a Roll OK.")
+
+        # 8. Delete the Last Roll
+        print("Testing Delete the Last Roll...")
+        await page.locator("#customRollsDisplayContainer > .displayed-roll").first.locator("button:has-text('Delete')").click()
+        await expect(page.locator("#customRollsDisplayContainer")).to_be_empty()
+        print("Delete the Last Roll OK.")
+
+        print("All tests passed!")
+        await browser.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
This commit introduces a new feature allowing you to define, save, and manage custom dice rolls on the character sheet.

Key changes:

- HTML (`index.html`):
  - Added a new "Custom Dice Rolls" section.
  - Includes a "+" button to add new roll definitions.
  - Provides containers for the roll creation form and the display of saved rolls.

- CSS (`style.css`):
  - Added styles for the new custom rolls section, forms, inputs, and displayed rolls to ensure visual consistency with the existing character sheet.

- JavaScript (`script.js`):
  - Implemented logic to dynamically create a form for defining a custom roll (description and number of dice for d4, d6, d8, d10, d12, d20, d100).
  - Added validation to ensure rolls have dice specified, and either dice or a description.
  - Custom rolls are stored in an in-memory array.
  - Saved rolls are displayed in a list, showing their description and dice configuration (e.g., "Fireball: 8d6").
  - You can delete saved custom rolls from the list.

The feature has been tested with automated checks covering adding, canceling, saving (with various input validations), displaying, and deleting rolls.