### PR TITLE
feat: Add Bonuses section for character sheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,6 +357,17 @@
             <!-- Saved custom rolls will be displayed here -->
           </div>
         </div>
+
+        <div id="bonusesSection">
+          <h2>Bonuses</h2>
+          <button id="addBonusBtn" aria-label="Add new bonus" style="font-size: 1.5em; padding: 5px 10px;">+</button>
+          <div id="bonusFormContainer">
+            <!-- New bonus forms will be injected here by JavaScript -->
+          </div>
+          <div id="bonusesDisplayContainer">
+            <!-- Saved bonuses will be displayed here -->
+          </div>
+        </div>
       </div> <!-- End main-right-column -->
     </div> <!-- End main-content -->
   </div> <!-- End sheet-container -->

--- a/style.css
+++ b/style.css
@@ -284,3 +284,142 @@ span { /* General spans, often used for "Modifier:" or "Total:" text */
   font-family: monospace; /* Good for dice strings like 2d6+1d4 */
   font-size: 0.95em;
 }
+
+/* Bonuses Section */
+#bonusesSection {
+  border: 1px solid #aaa;
+  padding: 10px;
+  border-radius: 3px; /* Subtle rounding */
+  margin-top: 15px; /* Space from the previous section */
+}
+
+#addBonusBtn {
+  font-size: 1.2em; /* Make '+' clearly visible */
+  padding: 5px 10px;
+  margin-bottom: 10px; /* Space before the form container */
+  cursor: pointer;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+
+#addBonusBtn:hover {
+  background-color: #e0e0e0;
+}
+
+#bonusFormContainer .bonus-form { /* Class for individual bonus forms */
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 10px;
+  background-color: #f9f9f9;
+  border-radius: 3px;
+}
+
+.bonus-form div { /* For layout of label/input pairs within the bonus form */
+  margin-bottom: 8px;
+  /* display: flex; Consider flex for more complex alignment if needed */
+  /* align-items: center; */
+}
+
+.bonus-form label {
+  min-width: 120px; /* Adjust as needed */
+  margin-right: 5px;
+  display: block; /* Make labels take their own line for now */
+  margin-bottom: 3px; /* Space between label and its control */
+}
+
+.bonus-form select,
+.bonus-form textarea,
+.bonus-form input[type="text"] { /* Assuming a text input might be used, though not in current plan */
+  width: 100%; /* Make them take full width of their container */
+  padding: 5px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+
+.bonus-form .checkbox-group label {
+    min-width: unset; /* Override default for checkbox labels */
+    display: inline-block; /* Keep checkbox and label on same line */
+    margin-right: 10px;
+    font-weight: normal;
+}
+.bonus-form .checkbox-group input[type="checkbox"] {
+    width: auto; /* Checkboxes should not be full width */
+    margin-right: 5px;
+}
+
+
+.bonus-form textarea {
+  min-height: 60px; /* Decent starting height for description */
+  resize: vertical; /* Allow vertical resizing */
+}
+
+.bonus-form button { /* Save/Cancel buttons for the bonus form */
+  padding: 6px 12px;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  margin-top: 5px;
+  margin-right: 5px; /* Space between buttons */
+}
+
+.bonus-form button.save-bonus-btn {
+  background-color: #4CAF50; /* Green for save */
+}
+.bonus-form button.save-bonus-btn:hover {
+  background-color: #45a049;
+}
+
+.bonus-form button.cancel-bonus-btn {
+  background-color: #f44336; /* Red for cancel */
+}
+.bonus-form button.cancel-bonus-btn:hover {
+  background-color: #da190b;
+}
+
+#bonusesDisplayContainer .displayed-bonus { /* Class for individual displayed bonuses */
+  border: 1px solid #ddd;
+  padding: 8px;
+  margin-bottom: 8px;
+  background-color: #fff;
+  border-radius: 3px;
+}
+
+.displayed-bonus .bonus-summary {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.displayed-bonus .bonus-applies-to {
+  font-style: italic;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.displayed-bonus .bonus-description {
+  font-size: 0.9em;
+  color: #333;
+  margin-bottom: 5px;
+}
+
+.displayed-bonus button.delete-bonus-btn {
+  padding: 3px 8px;
+  background-color: #dc3545; /* Red color for delete */
+  color: white;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 0.85em;
+  float: right; /* Position delete button to the right */
+}
+.displayed-bonus button.delete-bonus-btn:hover {
+  background-color: #c82333;
+}
+
+/* Clearfix for displayed-bonus if using float */
+#bonusesDisplayContainer .displayed-bonus::after {
+  content: "";
+  clear: both;
+  display: table;
+}


### PR DESCRIPTION
This commit introduces a new 'Bonuses' section to the Pathfinder character sheet.

Key features:
- You can add various types of bonuses (e.g., Alchemical, Armour, Circumstance, Competence, etc.).
- For each bonus, you can select what it applies to from a list of targets (e.g., AC, Saves, Attack Rolls, Skills) via checkboxes.
- A description can be added to each bonus for further details.
- Added bonuses are displayed in the 'Bonuses' section, showing their type, what they apply to, and the description.
- Each displayed bonus has a 'Delete' button to remove it.

I added new HTML structure to `index.html` for the section, add button, form container, and display area. I also added corresponding CSS styles in `style.css` for a consistent look and feel. I implemented JavaScript logic in `script.js` to:
    - Define bonus types and application targets.
    - Dynamically generate the bonus creation form.
    - Handle saving new bonuses to an in-memory array.
    - Render the list of saved bonuses.
    - Handle deletion of bonuses. The new section is placed in the right-hand column, below the 'Custom Dice Rolls' section.