### PR TITLE
Add dice roll buttons and pop-up modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,31 +37,37 @@
             <label for="strScore">Strength:</label>
             <input type="number" id="strScore" value="10">
             <span>Modifier: <span id="strMod">0</span></span>
+            <button class="roll-stat-btn" data-statname="Strength Check" data-modid="strMod">Roll</button>
           </div>
           <div>
             <label for="dexScore">Dexterity:</label>
             <input type="number" id="dexScore" value="10">
             <span>Modifier: <span id="dexMod">0</span></span>
+            <button class="roll-stat-btn" data-statname="Dexterity Check" data-modid="dexMod">Roll</button>
           </div>
           <div>
             <label for="conScore">Constitution:</label>
             <input type="number" id="conScore" value="10">
             <span>Modifier: <span id="conMod">0</span></span>
+            <button class="roll-stat-btn" data-statname="Constitution Check" data-modid="conMod">Roll</button>
           </div>
           <div>
             <label for="intScore">Intelligence:</label>
             <input type="number" id="intScore" value="10">
             <span>Modifier: <span id="intMod">0</span></span>
+            <button class="roll-stat-btn" data-statname="Intelligence Check" data-modid="intMod">Roll</button>
           </div>
           <div>
             <label for="wisScore">Wisdom:</label>
             <input type="number" id="wisScore" value="10">
             <span>Modifier: <span id="wisMod">0</span></span>
+            <button class="roll-stat-btn" data-statname="Wisdom Check" data-modid="wisMod">Roll</button>
           </div>
           <div>
             <label for="chaScore">Charisma:</label>
             <input type="number" id="chaScore" value="10">
             <span>Modifier: <span id="chaMod">0</span></span>
+            <button class="roll-stat-btn" data-statname="Charisma Check" data-modid="chaMod">Roll</button>
           </div>
         </div> <!-- End abilityScores -->
 
@@ -178,7 +184,7 @@
             <input type="checkbox" id="acrobaticsClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="acrobaticsClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="acrobaticsRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="acrobaticsTotal">0</span></span>
+            <span>Total: <span id="acrobaticsTotal">0</span></span><button class="roll-skill-btn" data-skillname="Acrobatics" data-totalid="acrobaticsTotal">Roll</button>
             <span id="acrobaticsClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -186,7 +192,7 @@
             <input type="checkbox" id="appraiseClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="appraiseClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="appraiseRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="appraiseTotal">0</span></span>
+            <span>Total: <span id="appraiseTotal">0</span></span><button class="roll-skill-btn" data-skillname="Appraise" data-totalid="appraiseTotal">Roll</button>
             <span id="appraiseClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -194,7 +200,7 @@
             <input type="checkbox" id="bluffClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="bluffClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="bluffRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="bluffTotal">0</span></span>
+            <span>Total: <span id="bluffTotal">0</span></span><button class="roll-skill-btn" data-skillname="Bluff" data-totalid="bluffTotal">Roll</button>
             <span id="bluffClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -202,7 +208,7 @@
             <input type="checkbox" id="climbClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="climbClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="climbRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="climbTotal">0</span></span>
+            <span>Total: <span id="climbTotal">0</span></span><button class="roll-skill-btn" data-skillname="Climb" data-totalid="climbTotal">Roll</button>
             <span id="climbClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -210,7 +216,7 @@
             <input type="checkbox" id="craftClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="craftClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="craftRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="craftTotal">0</span></span>
+            <span>Total: <span id="craftTotal">0</span></span><button class="roll-skill-btn" data-skillname="Craft" data-totalid="craftTotal">Roll</button>
             <span id="craftClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -218,7 +224,7 @@
             <input type="checkbox" id="diplomacyClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="diplomacyClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="diplomacyRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="diplomacyTotal">0</span></span>
+            <span>Total: <span id="diplomacyTotal">0</span></span><button class="roll-skill-btn" data-skillname="Diplomacy" data-totalid="diplomacyTotal">Roll</button>
             <span id="diplomacyClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -226,7 +232,7 @@
             <input type="checkbox" id="disableDeviceClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="disableDeviceClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="disableDeviceRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="disableDeviceTotal">0</span></span>
+            <span>Total: <span id="disableDeviceTotal">0</span></span><button class="roll-skill-btn" data-skillname="Disable Device" data-totalid="disableDeviceTotal">Roll</button>
             <span id="disableDeviceClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -234,7 +240,7 @@
             <input type="checkbox" id="disguiseClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="disguiseClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="disguiseRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="disguiseTotal">0</span></span>
+            <span>Total: <span id="disguiseTotal">0</span></span><button class="roll-skill-btn" data-skillname="Disguise" data-totalid="disguiseTotal">Roll</button>
             <span id="disguiseClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -242,7 +248,7 @@
             <input type="checkbox" id="escapeArtistClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="escapeArtistClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="escapeArtistRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="escapeArtistTotal">0</span></span>
+            <span>Total: <span id="escapeArtistTotal">0</span></span><button class="roll-skill-btn" data-skillname="Escape Artist" data-totalid="escapeArtistTotal">Roll</button>
             <span id="escapeArtistClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -250,7 +256,7 @@
             <input type="checkbox" id="flyClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="flyClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="flyRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="flyTotal">0</span></span>
+            <span>Total: <span id="flyTotal">0</span></span><button class="roll-skill-btn" data-skillname="Fly" data-totalid="flyTotal">Roll</button>
             <span id="flyClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -258,7 +264,7 @@
             <input type="checkbox" id="handleAnimalClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="handleAnimalClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="handleAnimalRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="handleAnimalTotal">0</span></span>
+            <span>Total: <span id="handleAnimalTotal">0</span></span><button class="roll-skill-btn" data-skillname="Handle Animal" data-totalid="handleAnimalTotal">Roll</button>
             <span id="handleAnimalClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -266,7 +272,7 @@
             <input type="checkbox" id="healClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="healClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="healRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="healTotal">0</span></span>
+            <span>Total: <span id="healTotal">0</span></span><button class="roll-skill-btn" data-skillname="Heal" data-totalid="healTotal">Roll</button>
             <span id="healClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -274,7 +280,7 @@
             <input type="checkbox" id="intimidateClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="intimidateClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="intimidateRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="intimidateTotal">0</span></span>
+            <span>Total: <span id="intimidateTotal">0</span></span><button class="roll-skill-btn" data-skillname="Intimidate" data-totalid="intimidateTotal">Roll</button>
             <span id="intimidateClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -282,7 +288,7 @@
             <input type="checkbox" id="knowledgeArcanaClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeArcanaClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeArcanaRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeArcanaTotal">0</span></span>
+            <span>Total: <span id="knowledgeArcanaTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Arcana)" data-totalid="knowledgeArcanaTotal">Roll</button>
             <span id="knowledgeArcanaClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -290,7 +296,7 @@
             <input type="checkbox" id="knowledgeDungeoneeringClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeDungeoneeringClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeDungeoneeringRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeDungeoneeringTotal">0</span></span>
+            <span>Total: <span id="knowledgeDungeoneeringTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Dungeoneering)" data-totalid="knowledgeDungeoneeringTotal">Roll</button>
             <span id="knowledgeDungeoneeringClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -298,7 +304,7 @@
             <input type="checkbox" id="knowledgeEngineeringClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeEngineeringClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeEngineeringRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeEngineeringTotal">0</span></span>
+            <span>Total: <span id="knowledgeEngineeringTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Engineering)" data-totalid="knowledgeEngineeringTotal">Roll</button>
             <span id="knowledgeEngineeringClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -306,7 +312,7 @@
             <input type="checkbox" id="knowledgeGeographyClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeGeographyClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeGeographyRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeGeographyTotal">0</span></span>
+            <span>Total: <span id="knowledgeGeographyTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Geography)" data-totalid="knowledgeGeographyTotal">Roll</button>
             <span id="knowledgeGeographyClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -314,7 +320,7 @@
             <input type="checkbox" id="knowledgeHistoryClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeHistoryClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeHistoryRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeHistoryTotal">0</span></span>
+            <span>Total: <span id="knowledgeHistoryTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (History)" data-totalid="knowledgeHistoryTotal">Roll</button>
             <span id="knowledgeHistoryClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -322,7 +328,7 @@
             <input type="checkbox" id="knowledgeLocalClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeLocalClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeLocalRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeLocalTotal">0</span></span>
+            <span>Total: <span id="knowledgeLocalTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Local)" data-totalid="knowledgeLocalTotal">Roll</button>
             <span id="knowledgeLocalClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -330,7 +336,7 @@
             <input type="checkbox" id="knowledgeNatureClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeNatureClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeNatureRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeNatureTotal">0</span></span>
+            <span>Total: <span id="knowledgeNatureTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Nature)" data-totalid="knowledgeNatureTotal">Roll</button>
             <span id="knowledgeNatureClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -338,7 +344,7 @@
             <input type="checkbox" id="knowledgeNobilityClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeNobilityClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeNobilityRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeNobilityTotal">0</span></span>
+            <span>Total: <span id="knowledgeNobilityTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Nobility)" data-totalid="knowledgeNobilityTotal">Roll</button>
             <span id="knowledgeNobilityClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -346,7 +352,7 @@
             <input type="checkbox" id="knowledgePlanesClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgePlanesClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgePlanesRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgePlanesTotal">0</span></span>
+            <span>Total: <span id="knowledgePlanesTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Planes)" data-totalid="knowledgePlanesTotal">Roll</button>
             <span id="knowledgePlanesClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -354,7 +360,7 @@
             <input type="checkbox" id="knowledgeReligionClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="knowledgeReligionClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="knowledgeReligionRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="knowledgeReligionTotal">0</span></span>
+            <span>Total: <span id="knowledgeReligionTotal">0</span></span><button class="roll-skill-btn" data-skillname="Knowledge (Religion)" data-totalid="knowledgeReligionTotal">Roll</button>
             <span id="knowledgeReligionClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -362,7 +368,7 @@
             <input type="checkbox" id="linguisticsClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="linguisticsClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="linguisticsRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="linguisticsTotal">0</span></span>
+            <span>Total: <span id="linguisticsTotal">0</span></span><button class="roll-skill-btn" data-skillname="Linguistics" data-totalid="linguisticsTotal">Roll</button>
             <span id="linguisticsClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -370,7 +376,7 @@
             <input type="checkbox" id="perceptionClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="perceptionClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="perceptionRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="perceptionTotal">0</span></span>
+            <span>Total: <span id="perceptionTotal">0</span></span><button class="roll-skill-btn" data-skillname="Perception" data-totalid="perceptionTotal">Roll</button>
             <span id="perceptionClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -378,7 +384,7 @@
             <input type="checkbox" id="performClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="performClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="performRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="performTotal">0</span></span>
+            <span>Total: <span id="performTotal">0</span></span><button class="roll-skill-btn" data-skillname="Perform" data-totalid="performTotal">Roll</button>
             <span id="performClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -386,7 +392,7 @@
             <input type="checkbox" id="professionClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="professionClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="professionRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="professionTotal">0</span></span>
+            <span>Total: <span id="professionTotal">0</span></span><button class="roll-skill-btn" data-skillname="Profession" data-totalid="professionTotal">Roll</button>
             <span id="professionClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -394,7 +400,7 @@
             <input type="checkbox" id="rideClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="rideClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="rideRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="rideTotal">0</span></span>
+            <span>Total: <span id="rideTotal">0</span></span><button class="roll-skill-btn" data-skillname="Ride" data-totalid="rideTotal">Roll</button>
             <span id="rideClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -402,7 +408,7 @@
             <input type="checkbox" id="senseMotiveClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="senseMotiveClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="senseMotiveRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="senseMotiveTotal">0</span></span>
+            <span>Total: <span id="senseMotiveTotal">0</span></span><button class="roll-skill-btn" data-skillname="Sense Motive" data-totalid="senseMotiveTotal">Roll</button>
             <span id="senseMotiveClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -410,7 +416,7 @@
             <input type="checkbox" id="sleightOfHandClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="sleightOfHandClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="sleightOfHandRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="sleightOfHandTotal">0</span></span>
+            <span>Total: <span id="sleightOfHandTotal">0</span></span><button class="roll-skill-btn" data-skillname="Sleight of Hand" data-totalid="sleightOfHandTotal">Roll</button>
             <span id="sleightOfHandClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -418,7 +424,7 @@
             <input type="checkbox" id="spellcraftClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="spellcraftClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="spellcraftRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="spellcraftTotal">0</span></span>
+            <span>Total: <span id="spellcraftTotal">0</span></span><button class="roll-skill-btn" data-skillname="Spellcraft" data-totalid="spellcraftTotal">Roll</button>
             <span id="spellcraftClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -426,7 +432,7 @@
             <input type="checkbox" id="stealthClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="stealthClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="stealthRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="stealthTotal">0</span></span>
+            <span>Total: <span id="stealthTotal">0</span></span><button class="roll-skill-btn" data-skillname="Stealth" data-totalid="stealthTotal">Roll</button>
             <span id="stealthClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -434,7 +440,7 @@
             <input type="checkbox" id="survivalClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="survivalClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="survivalRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="survivalTotal">0</span></span>
+            <span>Total: <span id="survivalTotal">0</span></span><button class="roll-skill-btn" data-skillname="Survival" data-totalid="survivalTotal">Roll</button>
             <span id="survivalClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -442,7 +448,7 @@
             <input type="checkbox" id="swimClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="swimClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="swimRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="swimTotal">0</span></span>
+            <span>Total: <span id="swimTotal">0</span></span><button class="roll-skill-btn" data-skillname="Swim" data-totalid="swimTotal">Roll</button>
             <span id="swimClassSkillText" class="class-skill-text-display"></span>
           </div>
           <div>
@@ -450,7 +456,7 @@
             <input type="checkbox" id="useMagicDeviceClassSkillChk" class="class-skill-checkbox" title="Mark as Class Skill">
             <label for="useMagicDeviceClassSkillChk" class="class-skill-checkbox-label">CS</label>
             <input type="number" id="useMagicDeviceRanks" value="0" class="skill-rank-input">
-            <span>Total: <span id="useMagicDeviceTotal">0</span></span>
+            <span>Total: <span id="useMagicDeviceTotal">0</span></span><button class="roll-skill-btn" data-skillname="Use Magic Device" data-totalid="useMagicDeviceTotal">Roll</button>
             <span id="useMagicDeviceClassSkillText" class="class-skill-text-display"></span>
           </div>
         </div> <!-- End skills -->
@@ -479,6 +485,15 @@
       </div> <!-- End main-right-column -->
     </div> <!-- End main-content -->
   </div> <!-- End sheet-container -->
+
+  <div id="rollResultModal" class="modal-hidden">
+    <div class="modal-content">
+      <span class="modal-close-btn">&times;</span>
+      <h3 id="modalTitle">Roll Result</h3>
+      <div id="modalResultText" style="font-size: 2em; text-align: center; margin-top: 15px;"></div>
+    </div>
+  </div>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -486,6 +486,32 @@ input.skill-rank-input {
     margin-left: auto; /* Push total to the right, utilizing flex space */
 }
 
+/* --- Roll Button Styles --- */
+.roll-skill-btn,
+.roll-stat-btn,
+.roll-custom-btn {
+  padding: 3px 8px; /* Adjusted padding */
+  font-size: 0.85em; /* Slightly larger for better readability */
+  margin-left: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px; /* Slightly more rounded */
+  background-color: #e9e9e9; /* Lighter grey for differentiation */
+  color: #333;
+  cursor: pointer;
+  vertical-align: middle;
+  line-height: 1; /* Ensure text is centered well if padding is uneven */
+  transition: background-color 0.15s ease-in-out; /* Smooth transition for hover */
+}
+
+.roll-skill-btn:hover,
+.roll-stat-btn:hover,
+.roll-custom-btn:hover {
+  background-color: #d5d5d5; /* Darken on hover */
+}
+
+/* Note: .roll-custom-btn specific styles (like its green background) are applied inline in JS for now.
+   If those were to be moved to CSS, they would override parts of the above. */
+
 /* --- Dark Mode Styles --- */
 body.dark-mode {
   background-color: #000033; /* Dark navy blue */
@@ -555,6 +581,29 @@ body.dark-mode .bonus-form button.cancel-bonus-btn:hover,
 body.dark-mode .displayed-bonus button.delete-bonus-btn:hover,
 body.dark-mode #customRollsDisplayContainer .displayed-roll button:hover {
   background-color: #a00000; /* Lighter red on hover */
+}
+
+/* Dark Mode Roll Button Styles (These are more specific than general dark mode button) */
+body.dark-mode .roll-skill-btn,
+body.dark-mode .roll-stat-btn,
+body.dark-mode .roll-custom-btn {
+  background-color: #2c2c60; /* Darker background for buttons */
+  color: #d0d0d0; /* Light text */
+  border-color: #505070; /* Border color for dark mode */
+}
+
+body.dark-mode .roll-skill-btn:hover,
+body.dark-mode .roll-stat-btn:hover,
+body.dark-mode .roll-custom-btn:hover {
+  background-color: #3a3a7a; /* Slightly lighter on hover in dark mode */
+}
+/* Ensure custom roll button (green in light mode) gets dark mode override if not handled by general button */
+body.dark-mode .roll-custom-btn { /* This selector is the same as above, so it's fine */
+    background-color: #1d6a2a; /* Darker green for dark mode */
+    border-color: #28502f;
+}
+body.dark-mode .roll-custom-btn:hover {
+    background-color: #278838; /* Slightly lighter green for hover in dark mode */
 }
 
 
@@ -652,3 +701,81 @@ body.dark-mode a {
 body.dark-mode a:hover {
   color: #b8ceff;
 }
+
+/* --- Modal Styles --- */
+.modal-hidden {
+  display: none;
+}
+
+.modal-visible {
+  display: flex; /* Use flex to center content */
+  position: fixed; /* Stay in place */
+  z-index: 1000; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgba(0,0,0,0.6); /* Black w/ opacity for overlay */
+  align-items: center; /* Vertical center */
+  justify-content: center; /* Horizontal center */
+}
+
+.modal-content {
+  background-color: #fefefe;
+  margin: auto; /* Auto margins for centering, though flex handles it */
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%;
+  max-width: 500px; /* Max width for the modal */
+  border-radius: 5px;
+  box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19);
+  position: relative; /* For positioning the close button */
+}
+
+.modal-close-btn {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.modal-close-btn:hover,
+.modal-close-btn:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+#modalTitle {
+  margin-top: 0;
+  margin-bottom: 15px;
+  text-align: center;
+}
+
+#modalResultText {
+  font-size: 1.8em; /* Large font for result, adjusted from 2em for balance */
+  text-align: center;
+  word-wrap: break-word; /* Ensure long descriptions wrap */
+}
+
+/* Dark Mode Modal Styles */
+body.dark-mode .modal-content {
+  background-color: #1a1a4a; /* Dark background for modal content */
+  color: #e0e0e0; /* Light text */
+  border-color: #555; /* Darker border */
+}
+
+body.dark-mode .modal-close-btn {
+  color: #ccc; /* Lighter close button for dark mode */
+}
+
+body.dark-mode .modal-close-btn:hover,
+body.dark-mode .modal-close-btn:focus {
+  color: #fff; /* White hover/focus for close button */
+}
+
+body.dark-mode #modalTitle {
+   color: #c0c0ff; /* Matching h2 in dark mode */
+}
+/* modalResultText color will be inherited from .modal-content */


### PR DESCRIPTION
This commit introduces functionality to allow you to roll dice directly from the character sheet for skills, ability scores, and custom dice configurations.

Key changes:

- **Roll Buttons:** Added 'Roll' buttons next to each skill total, ability score modifier, and saved custom roll.
- **Dice Rolling Logic:** Implemented a `rollDice(diceNotation)` function in `script.js` that can parse strings like "1d20+5", "2d6-2", or "1d8+1d4" and return the total result along with a descriptive string of the rolls.
- **Pop-up Modal:** Created a modal dialog to display the roll results. The modal shows a title indicating what was rolled (e.g., "Acrobatics Roll") and the detailed outcome from `rollDice()`. The modal is styled for both light and dark themes and can be closed via a button or by clicking the overlay.
- **HTML Updates:** Modified `index.html` to include the new buttons and the modal structure.
- **CSS Styling:** Added styles in `style.css` for the new roll buttons and the modal, ensuring they are visually consistent with the sheet and work in both light and dark modes.
- **JavaScript Enhancements:**
    - Event listeners were added to all new roll buttons to trigger the appropriate dice roll (1d20 + bonus for skills/stats, specified dice for custom rolls).
    - The `renderCustomRolls` function was updated to include 'Roll' buttons for each custom roll.
    - Functions `showModal()` and `hideModal()` were added to manage the display of the roll result pop-up.

Testing confirmed that skill rolls, ability score checks, and custom dice rolls (without static modifiers) function correctly. The modal displays results clearly.

A known limitation is that the current custom roll UI does not support adding static modifiers (e.g., +2) to a custom roll; it only supports combinations of dice. The `rollDice` function itself can parse such modifiers if the notation is provided directly.