### PR TITLE
Fix: Remove duplicate variable declarations in rollDice

### DIFF
--- a/script.js
+++ b/script.js
@@ -429,7 +429,6 @@ function rollDice(diceNotation) {
   // e.g., "5+2d6" -> ["5", "+2d6"]
   const terms = normalizedNotation.match(/[+\-]?[^+\-]+/g) || [];
   let firstTermProcessed = false;
-  let firstTermProcessed = false;
 
   for (let i = 0; i < terms.length; i++) {
     let term = terms[i];
@@ -438,7 +437,6 @@ function rollDice(diceNotation) {
 
     // For the very first term, if it's a number and has no explicit sign, it's positive.
     // If it's a dice roll like "d20", it's also positive.
-    let termValueStr = term.replace(/^[+\-]/, ''); // Remove leading + or - to get the value part
 
     // If it's the first term and has no sign, it's implicitly positive.
 


### PR DESCRIPTION
Removes duplicate declarations of `firstTermProcessed` and `termValueStr` in the `rollDice` function to resolve a SyntaxError.