### PR TITLE
Fix: Correct syntax error in rollDice function

### DIFF
--- a/script.js
+++ b/script.js
@@ -470,7 +470,6 @@ function rollDice(diceNotationInput) {
       }
     }
     firstTermProcessed = true;
-    }
   }
 
   rollsDescription += individualRolls.length > 0 ? individualRolls.join(', ') : "None";


### PR DESCRIPTION
Removes an extraneous closing curly brace within the `rollDice` function in `script.js`. This brace prematurely closed a for-loop, leading to a "missing ) after argument list" syntax error on a subsequent line.

The fix ensures the for-loop correctly encompasses all its intended statements, resolving the parsing error.