### PR TITLE
Fix: Structure webhookData for Discord API compatibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -302,6 +302,40 @@ function updateAllCharacterSheetCalculations() {
   console.log("[DEBUG] updateAllCharacterSheetCalculations completed");
 }
 
+// --- Webhook Function ---
+function sendToWebhook(webhookData) {
+  const webhookUrl = localStorage.getItem('webhookUrl');
+
+  if (!webhookUrl) {
+    console.log('[Webhook] No webhook URL configured. Skipping send.');
+    return;
+  }
+
+  console.log('[Webhook] Sending data to:', webhookUrl, webhookData);
+
+  fetch(webhookUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(webhookData),
+  })
+  .then(response => {
+    if (!response.ok) {
+      // Log the response status and text for more detailed error info
+      response.text().then(text => {
+        console.error('[Webhook] Error sending data:', response.status, response.statusText, text);
+      });
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    console.log('[Webhook] Data sent successfully:', response.status);
+    // It might be useful to log response.json() if the webhook returns a meaningful body
+    // return response.json();
+  })
+  .catch(error => {
+    console.error('[Webhook] Failed to send data:', error);
+  });
+}
 
 // --- Event Listeners & Initial Calculation ---
 document.addEventListener('DOMContentLoaded', () => {
@@ -470,7 +504,6 @@ function rollDice(diceNotationInput) {
       }
     }
     firstTermProcessed = true;
-    }
   }
 
   rollsDescription += individualRolls.length > 0 ? individualRolls.join(', ') : "None";
@@ -640,6 +673,7 @@ function rollDice(diceNotationInput) {
 
             // Prepare and send to webhook
             const webhookData = {
+              content: result.rollsDescription,
               roll_type: `Custom: ${roll.description}`,
               dice_notation: result.diceNotation, // or just diceNotation variable from above
               individual_rolls: result.individualRolls,
@@ -768,6 +802,7 @@ function rollDice(diceNotationInput) {
 
         // Prepare and send to webhook
         const webhookData = {
+          content: result.rollsDescription,
           roll_type: `Skill: ${skillName}`,
           dice_notation: result.diceNotation,
           individual_rolls: result.individualRolls,
@@ -796,6 +831,7 @@ function rollDice(diceNotationInput) {
 
         // Prepare and send to webhook
         const webhookData = {
+          content: result.rollsDescription,
           roll_type: `Stat: ${statName}`,
           dice_notation: result.diceNotation,
           individual_rolls: result.individualRolls,


### PR DESCRIPTION
Modifies the `webhookData` object in `script.js` to include a `content` field, populated with `result.rollsDescription`. This ensures that data sent to Discord webhooks is not treated as an empty message.

This resolves the "400 Bad Request" error (Discord error code 50006: "Cannot send an empty message") when sending roll results to a Discord webhook. The `full_description` field is retained in the payload for potential use by other non-Discord webhook processors, while `content` addresses Discord's specific requirement.