### PR TITLE
Fix: Correct SyntaxError in webhookData object

### DIFF
--- a/script.js
+++ b/script.js
@@ -825,7 +825,7 @@ function rollDice(diceNotationInput) {
 *${result.diceNotation} (Rolls: ${result.individualRolls.join(', ')}) Modifier: ${result.modifier >= 0 ? '+' : ''}${result.modifier}*`,
             color: 5814783, // Blue
             timestamp: new Date().toISOString(),
-          }]
+          }],
           content: result.rollsDescription,
           roll_type: `Skill: ${skillName}`,
           dice_notation: result.diceNotation,


### PR DESCRIPTION
Adds a missing comma after the 'embeds' array within the 'webhookData' object in the 'renderCustomRolls' function.

This resolves the "Uncaught SyntaxError: Unexpected identifier 'content'" error that occurred at script.js:688:15.