### PR TITLE
Fix: Remove redundant variable declarations in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -495,27 +495,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // as they are already declared above or not strictly needed for this logging section.
   // const signupButton = document.getElementById('signup-button');
   // const loginButton = document.getElementById('login-button');
-  // --- Auth DOM Elements ---
-  const authContainer = document.getElementById('auth-container');
-  const signupForm = document.getElementById('signup-form');
-  const signupEmailInput = document.getElementById('signup-email');
-  const signupPasswordInput = document.getElementById('signup-password');
-  const signupButton = document.getElementById('signup-button');
-  const loginForm = document.getElementById('login-form');
-  const loginEmailInput = document.getElementById('login-email');
-  const loginPasswordInput = document.getElementById('login-password');
-  const loginButton = document.getElementById('login-button');
-  const logoutButton = document.getElementById('logout-button');
-  const emailVerificationMessageDiv = document.getElementById('email-verification-message');
-  const sheetContainer = document.getElementById('sheet-container');
-
-  // --- Character Sheet Management DOM Elements ---
-  const characterSheetManagementDiv = document.getElementById('character-sheet-management');
-  const saveSheetButton = document.getElementById('save-sheet-button');
-  const sheetNameInput = document.getElementById('sheet-name-input');
-  const loadSheetButton = document.getElementById('load-sheet-button'); // This is "Refresh Saved Sheets"
-  const savedSheetsListDiv = document.getElementById('saved-sheets-list');
-
+  // Note: The redundant block of const declarations that was here has been removed.
 
   // --- User State Management ---
   function updateLoginState(isLoggedIn, userEmail = '', isVerified = false) {


### PR DESCRIPTION
Removes a duplicate block of `const` declarations within the DOMContentLoaded event listener. This resolves the "Uncaught SyntaxError: Identifier 'authContainer' has already been declared" (and similar errors for other variables) by ensuring these DOM element references are declared only once.

The initial declarations of these constants were preserved, so functionality remains unaffected.